### PR TITLE
CP3

### DIFF
--- a/connect/eaas/dataclasses.py
+++ b/connect/eaas/dataclasses.py
@@ -56,7 +56,7 @@ class TaskPayload:
     result: str = None
     data: Any = None
     countdown: int = 0
-    failure_output: str = None
+    output: str = None
     correlation_id: str = None
     reply_to: str = None
 

--- a/connect/eaas/extension.py
+++ b/connect/eaas/extension.py
@@ -17,17 +17,18 @@ class _Response:
 
 class ProcessingResponse(_Response):
 
-    def __init__(self, status, countdown=0):
+    def __init__(self, status, countdown=0, output=None):
         super().__init__(status)
         self.countdown = countdown
+        self.output = output
 
     @classmethod
     def done(cls):
         return cls(ResultType.SUCCESS)
 
     @classmethod
-    def skip(cls):
-        return cls(ResultType.SKIP)
+    def skip(cls, output=None):
+        return cls(ResultType.SKIP, output=output)
 
     @classmethod
     def reschedule(cls, countdown=30):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -19,6 +19,12 @@ def test_result_skip():
     assert ProcessingResponse.skip().status == ResultType.SKIP
 
 
+def test_result_skip_with_output():
+    skip = ProcessingResponse.skip('output')
+    assert skip.status == ResultType.SKIP
+    assert skip.output == 'output'
+
+
 def test_result_reschedule():
     r = ProcessingResponse.reschedule(60)
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -102,6 +102,7 @@ async def test_background_task_sync_unsupported_status(mocker, extension_cls):
     message = Message(message_type=MessageType.TASK, data=task)
     json_msg = message.to_json()
     json_msg['data']['result'] = ResultType.SKIP
+    json_msg['data']['output'] = 'The status approved is not supported by the extension.'
     worker.send.assert_awaited_once_with(json_msg)
 
 
@@ -245,7 +246,7 @@ async def test_background_task_request_error(mocker, extension_cls):
     message = Message(message_type=MessageType.TASK, data=task)
     json_msg = message.to_json()
     json_msg['data']['result'] = 'retry'
-    json_msg['data']['failure_output'] = 'Request not found'
+    json_msg['data']['output'] = 'Request not found'
     worker.send.assert_awaited_once_with(json_msg)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,5 +16,5 @@ testpaths = tests
 addopts = -v --cov=connect.eaas --cov-report=term-missing:skip-covered --cov-report=html --cov-report=xml
 python_files = test_*.py
 junit_family = xunit2
-log_cli = true
-log_cli_level = DEBUG
+log_cli = false
+log_cli_level = INFO


### PR DESCRIPTION
Rename failure_output to just "output".
Add support for output string on skip results.
Add skip output message when status is unsupported.