### PR TITLE
Runner improvements

### DIFF
--- a/connect/eaas/extension.py
+++ b/connect/eaas/extension.py
@@ -17,9 +17,9 @@ class _Response:
 
 class ProcessingResponse(_Response):
 
-    def __init__(self, status, countdown=0, output=None):
+    def __init__(self, status, countdown=30, output=None):
         super().__init__(status)
-        self.countdown = countdown
+        self.countdown = 30 if countdown < 30 else countdown
         self.output = output
 
     @classmethod
@@ -34,23 +34,40 @@ class ProcessingResponse(_Response):
     def reschedule(cls, countdown=30):
         return cls(ResultType.RESCHEDULE, countdown=countdown)
 
+    @classmethod
+    def slow_process_reschedule(cls, countdown=300):
+        return cls(
+            ResultType.RESCHEDULE,
+            countdown=300 if countdown < 300 else countdown,
+        )
+
+    @classmethod
+    def fail(cls, output=None):
+        return cls(ResultType.FAIL, output=output)
+
 
 class ValidationResponse(_Response):
-    def __init__(self, status, data):
+    def __init__(self, status, data, output=None):
         super().__init__(status)
         self.data = data
+        self.output = output
 
     @classmethod
     def done(cls, data):
         return cls(ResultType.SUCCESS, data)
 
+    @classmethod
+    def fail(cls, data=None, output=None):
+        return cls(ResultType.FAIL, data=data, output=output)
+
 
 class _InteractiveTaskResponse(_Response):
-    def __init__(self, status, http_status, headers, body):
+    def __init__(self, status, http_status, headers, body, output):
         super().__init__(status)
         self.http_status = http_status
         self.headers = headers
         self.body = body
+        self.output = output
 
     @property
     def data(self):
@@ -62,7 +79,11 @@ class _InteractiveTaskResponse(_Response):
 
     @classmethod
     def done(cls, http_status=200, headers=None, body=None):
-        return cls(ResultType.SUCCESS, http_status, headers, body)
+        return cls(ResultType.SUCCESS, http_status, headers, body, None)
+
+    @classmethod
+    def fail(cls, http_status=400, headers=None, body=None, output=None):
+        return cls(ResultType.FAIL, http_status, headers, body, output)
 
 
 class CustomEventResponse(_InteractiveTaskResponse):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,14 +35,18 @@ def ws_server(unused_port):
 
 @pytest.fixture
 def extension_cls():
-    def _extension(method_name, result=None, async_impl=False):
+    def _extension(method_name, result=None, async_impl=False, exception=None):
         class TestExtension(Extension):
             pass
 
         def ext_method(self, request):
+            if exception:
+                raise exception
             return result or ProcessingResponse.done()
 
         async def async_ext_method(self, request):
+            if exception:
+                raise exception
             return result or ProcessingResponse.done()
 
         if async_impl:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,0 +1,54 @@
+from connect.eaas.dataclasses import (
+    CapabilitiesPayload,
+    ConfigurationPayload,
+    Message,
+    MessageType,
+
+)
+
+
+def test_capabilities_payload():
+    assert CapabilitiesPayload(
+        {'cap1': 'val1'},
+        'https://example.com/readme',
+        'https://example.com/changelog',
+    ).to_json() == {
+        'capabilities': {'cap1': 'val1'},
+        'readme_url': 'https://example.com/readme',
+        'changelog_url': 'https://example.com/changelog',
+    }
+
+
+def test_configuration_payload():
+    assert ConfigurationPayload(
+        {'conf1': 'val1'},
+        'logging-token',
+        'environ-type',
+        'log-level',
+        'runner-log-level',
+    ).to_json() == {
+        'configuration': {'conf1': 'val1'},
+        'logging_api_key': 'logging-token',
+        'environment_type': 'environ-type',
+        'log_level': 'log-level',
+        'runner_log_level': 'runner-log-level',
+    }
+
+
+def test_message_capabilities():
+    cap = CapabilitiesPayload(
+        {'cap1': 'val1'},
+        'https://example.com/readme',
+        'https://example.com/changelog',
+    )
+
+    msg = Message(
+        MessageType.CAPABILITIES,
+        cap.to_json(),
+    )
+    assert msg.data == cap
+
+    assert msg.to_json() == {
+        'message_type': MessageType.CAPABILITIES,
+        'data': cap.to_json(),
+    }


### PR DESCRIPTION
Enh: Provides methods for failing a task to all response types
Enh: log exceptions raised inside extension and catched in task manager using extension logger also
Fix: Return default data body for Product Actions and Custom Events
Fix: accept countdown >= 30 seconds (if lower set limit)