### PR TITLE
Fix generic exceptions left the runner in a stuck state

### DIFF
--- a/connect/eaas/exceptions.py
+++ b/connect/eaas/exceptions.py
@@ -13,3 +13,7 @@ class MaintenanceError(EaaSError):
 
 class CommunicationError(EaaSError):
     pass
+
+
+class StopBackoffError(EaaSError):
+    pass


### PR DESCRIPTION
Catch generic exception to have the last chance to exit cleanly.
Improve giveup handler.
Apply backoff policy to generic WebSocket errors.