### PR TITLE
LITE-34126: Fix Docker build on Debian Trixie base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     # libatomic1 for arm
     && DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
-    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \
@@ -39,14 +38,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-    && apt-mark auto '.*' > /dev/null \
-    && find /usr/local -type f -executable -exec ldd '{}' ';' \
-      | awk '/=>/ { print $(NF-1) }' \
-      | sort -u \
-      | xargs -r dpkg-query --search \
-      | cut -d: -f1 \
-      | sort -u \
-      | xargs -r apt-mark manual \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
     # smoke tests
     && node --version \


### PR DESCRIPTION
## Summary

The deploy workflow started failing on every new tag because the Docker image build broke in the Node.js install step. Root cause is upstream, not in our code: python:3.10-slim was rebased onto Debian Trixie, which changed dpkg-query --search output and introduced the t64 package rename transition — both of which are incompatible with the package-cleanup pipeline we had inherited from the official Node.js image.

## Root cause

The failing RUN block (old Dockerfile:42-49) did:

1. apt-mark auto '.*' — mark every installed package as auto-removable.
2. find /usr/local -executable -exec ldd … | awk … | xargs dpkg-query --search | cut -d: -f1 | xargs apt-mark manual — re-discover which packages provide the shared libs Node needs, and re-mark those as manual.

On Trixie, dpkg-query --search emits extra diversion by … from: … to: … lines for libc-bin diversions. Those lines got split by cut/xargs into the literal tokens diversion, by, from, to, which were then passed to apt-mark manual as if they were package names. apt-mark failed on the bogus names, xargs returned exit code 123, and the whole RUN step died.

## Fix

Removed the apt-mark auto / ldd / dpkg-query / apt-mark manual block entirely. It's boilerplate copied from the official Node.js Docker image, intended as an aggressive cleanup optimization, but it was never load-bearing here:

- The shared libs Node depends on (libc, libstdc++, libgcc, zlib, …) are part of the python:3.10-slim base and already marked manual, so apt-get autoremove later in the Dockerfile would never have removed them anyway.
- The autoremove at the end of the file is really there to clean up gcc's dependencies after apt-get purge gcc, and that still works correctly without this block.

Also dropped apt-get upgrade -y from the same RUN step. It made builds non-reproducible (output depends on when the build runs) and added an extra failure surface for no real benefit — the upstream python:3.10-slim rebuild already carries security patches.

## Test
- Built locally for both architectures: docker buildx build --platform linux/amd64,linux/arm64 --build-arg RUNNER_VERSION=0.0.0 . — succeeds.
