### PR TITLE
Isolate asyncio event loop policy per test to stop uvloop leaking across tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2022 Ingram Micro. All Rights Reserved.
 #
+import asyncio
 import contextlib
 import socket
 
@@ -22,6 +23,25 @@ from connect.eaas.core.responses import (
 from connect.eaas.runner.constants import (
     BACKGROUND_EVENT_TYPES,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_event_loop_policy():
+    """Restore the global asyncio event loop policy after every test.
+
+    ``connect.eaas.runner.main`` calls ``uvloop.install()``, which sets the
+    *global* event loop policy to uvloop. Without isolation a test that triggers
+    it leaves uvloop installed for every later test (``pytest-randomly`` runs
+    them in random order); uvloop loops then fail at teardown
+    ("Cannot close a running event loop" / "Bad file descriptor") and poison
+    unrelated async tests ("this event loop is already running"). Saving and
+    restoring the policy around each test keeps them isolated.
+    """
+    policy = asyncio.get_event_loop_policy()
+    try:
+        yield
+    finally:
+        asyncio.set_event_loop_policy(policy)
 
 
 @pytest.fixture

--- a/tests/workers/test_transformations.py
+++ b/tests/workers/test_transformations.py
@@ -132,7 +132,6 @@ async def test_extension_settings(mocker, ws_server, unused_port, tfn_settings_p
     handler.assert_received(msg.dict())
 
 
-@pytest.mark.flaky(max_runs=3, min_passes=1)
 @pytest.mark.asyncio
 async def test_shutdown(mocker, ws_server, unused_port, tfn_settings_payload):
 
@@ -286,7 +285,6 @@ async def test_shutdown_pending_task_timeout(
     assert 'Cannot send all results timeout of 0.2 exceeded, cancel task' in caplog.text
 
 
-@pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_start_tfnapp_worker_process(mocker):
     start_mock = mocker.AsyncMock()
 
@@ -450,7 +448,6 @@ async def test_task(
     )
 
 
-@pytest.mark.flaky(max_runs=3, min_passes=1)
 @pytest.mark.asyncio
 async def test_sender_max_retries_exceeded(mocker, tfn_settings_payload, task_payload, caplog):
     mocker.patch('connect.eaas.runner.workers.transformations.RESULT_SENDER_MAX_RETRIES', 3)


### PR DESCRIPTION
## Problem

The test suite fails intermittently in CI with `RuntimeError: this event loop is already running`, `RuntimeError: Cannot close a running event loop` and `OSError: [Errno 9] Bad file descriptor`, sometimes cascading across 100+ async tests. The set of failing tests changes from run to run.

## Root cause

`tests/test_main.py` calls `main()`, which runs `uvloop.install()` — this sets the **global** asyncio event loop policy to uvloop. Because `pytest-randomly` runs tests in random order, whenever that test runs early the uvloop policy leaks into every subsequent test. uvloop's stricter loop teardown (notably around signal-handler file descriptors on Linux) then fails when a test leaves a worker task running, and the broken loop poisons the rest of the session. This is order- and platform-dependent (Linux CI), which is why it looks flaky.

## Fix

Add an autouse fixture in `tests/conftest.py` that saves and restores the global event loop policy around every test, so `uvloop.install()` can no longer leak between tests.

Also remove the three `@pytest.mark.flaky` markers added earlier as a stopgap — they don't help, since the failure cascades across many tests and the affected set varies by run order.

## Verification

Full suite green across 12+ `pytest-randomly` seeds locally (330 passed each), including a seed that previously surfaced the uvloop teardown failure.
